### PR TITLE
Automatically set $incrementing to false when saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $id = $snowflake->next();
 ```
 # Usage with Eloquent
 Add the `Kra8\Snowflake\HasSnowflakePrimary` trait to your Eloquent model.
-This trait make type `snowflake` of primary key.  Don't forget to set the Auto increment property to false.
+This trait make type `snowflake` of primary key. Trait will automatically set $incrementing property to false.
 
 ``` php
 <?php
@@ -54,13 +54,6 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 class User extends Authenticatable
 {
     use HasSnowflakePrimary, Notifiable;
-
-    /**
-     * Indicates if the IDs are auto-incrementing.
-     *
-     * @var bool
-     */
-    public $incrementing = false;
 }
 ```
 

--- a/src/HasSnowflakePrimary.php
+++ b/src/HasSnowflakePrimary.php
@@ -9,6 +9,7 @@ trait HasSnowflakePrimary
     {
         static::saving(function ($model) {
             if (is_null($model->getKey())) {
+                $model->setIncrementing(false);
                 $keyName    = $model->getKeyName();
                 $id         = app(Snowflake::class)->next();
                 $model->setAttribute($keyName, $id);


### PR DESCRIPTION
To save time and code I've added a line inside the SnowflakePrimary trait to set the $incrementing property on the model to false before setting the $id.

The only downside to this is if anything is calling the `getIncrementing()` method directly it will show that it's true since the value is only changed when the model is being saved. It won't affect someone directly changing the property in their model.