### PR TITLE
doc: fix trait name for short flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 /vendor
+/.vscode
 
 .phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ To use it, simply change HasSnowflakePrimary to HasShortPrimary.
 <?php
 namespace App;
 
-use Kra8\Snowflake\HasShortPrimary;
+use Kra8\Snowflake\HasShortflakePrimary;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
 class User extends Authenticatable
 {
-    use HasShortPrimary, Notifiable;
+    use HasShortflakePrimary, Notifiable;
 }
 ```
 


### PR DESCRIPTION
Invalid trait name on the doc on how to use short flake. it should be [`HasShortflakePrimary`](https://github.com/pararang/laravel-snowflake/blob/1caab31cdf9dd7c888bab0b7f208a4e4fc63038f/src/HasShortflakePrimary.php#L7) instead of `HasShortPrimary`.

![Screen Shot 2022-07-17 at 16 01 00](https://user-images.githubusercontent.com/8720184/179389692-03720c75-a681-41c8-95ab-6da145d1cc8c.jpg)

