### PR TITLE
Support for 8.4 nullable parameter

### DIFF
--- a/src/Snowflake.php
+++ b/src/Snowflake.php
@@ -60,7 +60,7 @@ class Snowflake
     /**
      * Create a new Snowflake instance.
      */
-    public function __construct(int $timestamp = null, int $workerId = 1, int $datacenterId = 1)
+    public function __construct(?int $timestamp = null, int $workerId = 1, int $datacenterId = 1)
     {
         if ($timestamp === null) {
             $timestamp = strtotime(self::DEFAULT_EPOCH_DATETIME);


### PR DESCRIPTION
Fix Notice:
`Implicitly marking parameter $timestamp as nullable is deprecated, the explicit nullable type must be used instead `